### PR TITLE
add a redirect for /survey to a usabilla survey

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,1 @@
+survey/?: "https://survey.usabilla.com/live/s/6346b3cd4b9c4104b76e0c80"


### PR DESCRIPTION
## Done

Added a redirect from /survey to a Usabilla URL, the idea being that Tytus and co can use microstack.run/survey in CLI output to drive engagement with a survey they're running.

## QA

- visit https://microstack-run-199.demos.haus/survey
- see that you are redirected to a Usabilla survey

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6095
