### PR TITLE
Use latest discourse module to fix caching issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.4.1
+canonicalwebteam.discourse==5.4.2
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
Microstack.run is using the bad version of canonicalwebteam.discourse which leads to index page caching.

Fixes https://warthogs.atlassian.net/browse/WD-4503
Fixes https://github.com/canonical/canonicalwebteam.discourse/issues/165

## QA

Go to https://microstack-run-233.demos.haus/docs. Change some content. Refresh.

Bear in mind that page rules set cache timeout to 1 minute anyway, so it might take 1 minute for your browser to show you the latest version.
