### PR TITLE
Replace microk8s with microstack in title for docs pages

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -1,6 +1,6 @@
 {% extends "base_layout.html" %}
 
-{% block title %}MicroK8s - {{ document.title }} {% endblock %}
+{% block title %}MicroStack - {{ document.title }} {% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

Replace microk8s with microstack in title for docs pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/docs
- Check tab title now says MicroStack - .. instead of MicroK8s - ...
