### PR TITLE
Embbed 'how to install openstack' video in homepage

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -6,6 +6,7 @@ $color-accent: $ubuntu-orange;
 $theme-default-nav: dark;
 $color-navigation-background: $mine-shaft;
 $color-navigation-active-bar: $ubuntu-orange;
+$color-brand: $mine-shaft;
 
 // Sidebar
 $content-padding: 0 5%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,12 +13,19 @@ MicroStack delivers distilled OpenStack excellence with native K8s experience. O
 
 <main id="main-content">
   <section class="p-strip--suru is-dark">
-    <div class="u-fixed-width">
-      <h1>OpenStack on Kubernetes</h1>
-      <p class="p-heading--four">Distilled upstream excellence with a native K8s experience.</p>
-      <p>
-        <a class="p-button--positive" href="#get-started">Try MicroStack</a> &nbsp;and break the ice with OpenStack today!
-      </p>
+    <div class="row">
+      <div class="col-6">
+        <h1>OpenStack on Kubernetes</h1>
+        <p class="p-heading--four">Distilled upstream excellence with a native K8s experience.</p>
+        <p>
+          <a class="p-button--positive" href="#get-started">Try MicroStack</a> &nbsp;and break the ice with OpenStack today!
+        </p>
+      </div>
+      <div class="col-6">
+        <div class="u-embedded-media">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/ifDtBM_EHPE" title="How to Install OpenStack in five simple steps | OpenStack tutorial for beginners | Ubuntu LTS" frameborder="0" allow="clipboard-write; encrypted-media; picture-in-picture; web-share" allowfullscreen></iframe>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,9 +22,7 @@ MicroStack delivers distilled OpenStack excellence with native K8s experience. O
         </p>
       </div>
       <div class="col-6">
-        <div class="u-embedded-media">
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/ifDtBM_EHPE" title="How to Install OpenStack in five simple steps | OpenStack tutorial for beginners | Ubuntu LTS" frameborder="0" allow="clipboard-write; encrypted-media; picture-in-picture; web-share" allowfullscreen></iframe>
-        </div>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/ifDtBM_EHPE" title="How to Install OpenStack in five simple steps | OpenStack tutorial for beginners | Ubuntu LTS" frameborder="0" allow="clipboard-write; encrypted-media; picture-in-picture; web-share" allowfullscreen></iframe>
       </div>
     </div>
   </section>
@@ -412,7 +410,7 @@ MicroStack delivers distilled OpenStack excellence with native K8s experience. O
       <div class="col-6 p-card">
         <img class="p-card__thumbnail--large" src="https://assets.ubuntu.com/v1/67d90042-compliance-icon-no-padding.svg" alt="">
         <hr class="u-sv1">
-        <p><a href="https://www.openstack.org/user-survey/survey-2022/landing">Fill in the survey&nbsp;&rsaquo;</a></p>
+        <p><a href="https://www.openstack.org/user-survey/survey-2024/landing">Fill in the survey&nbsp;&rsaquo;</a></p>
         <p class="p-card__content">The OpenStack User Survey provides users an opportunity to influence the community and software direction. By sharing information about your configuration and requirements, the Open Infrastructure Foundation User Committee will be able to advocate on your behalf.</p>
       </div>
       <div class="col-6 p-card">


### PR DESCRIPTION
## Done

- Embbed 'how to install openstack' video in homepage based on [copydoc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6019
