### PR TITLE
WD-7449 - update link to Chat

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -21,7 +21,7 @@
             <a class="p-navigation__link" href="/docs">Docs</a>
           </li>
           <li class="p-navigation__item" role="menuitem">
-            <a class="p-navigation__link" href="https://discourse.charmhub.io/tag/microstack">Chat</a>
+            <a class="p-navigation__link" href="https://chat.charmhub.io/charmhub/channels/sunbeam">Chat</a>
           </li>
           <li class="p-navigation__item" role="menuitem">
             <a class="p-navigation__link" href="https://github.com/openstack-snaps/snap-openstack">Contribute</a>


### PR DESCRIPTION
## Done

- Updated link to Chat in the nav bar

## QA

- [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit#heading=h.4t7jro4ogj)
- [demo link](https://microstack-run-247.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check that link to Chat is correct

## Issue / Card
[WD-7449](https://warthogs.atlassian.net/browse/WD-7449)
Fixes #

## Screenshots


## Help

[WD-7449]: https://warthogs.atlassian.net/browse/WD-7449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ