### PR TITLE
WD-8501 - update chat nav link

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -21,7 +21,7 @@
             <a class="p-navigation__link" href="/docs">Docs</a>
           </li>
           <li class="p-navigation__item" role="menuitem">
-            <a class="p-navigation__link" href="https://chat.charmhub.io/charmhub/channels/sunbeam">Chat</a>
+            <a class="p-navigation__link" href="https://matrix.to/#/#openstack-sunbeam:ubuntu.com">Chat</a>
           </li>
           <li class="p-navigation__item" role="menuitem">
             <a class="p-navigation__link" href="https://github.com/openstack-snaps/snap-openstack">Contribute</a>


### PR DESCRIPTION
## Done

- Updated link to Chat in the nav bar

## QA

- [copy doc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit)
- [demo link](https://microstack-run-250.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8039/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check that link to Chat is correct

## Issue / Card
[WD-8501](https://warthogs.atlassian.net/browse/WD-8501)
Fixes #

## Screenshots


## Help

[WD-8501]: https://warthogs.atlassian.net/browse/WD-8501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ