### PR TITLE
Use dotrun for tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,12 +77,12 @@ jobs:
       - name: Install dotrun
         uses: canonical/install-dotrun@main
 
-      - name: Install node dependencies
+      - name: Install dependencies
         run: |
           sudo chmod -R 777 .
           dotrun install
 
-      - name: Install dependencies
+      - name: Install coverage
         run: dotrun exec pip3 install coverage
 
       - name: Build resources

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,28 +68,29 @@ jobs:
         run: yarn lint-scss
 
   test-python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Install requirements
-        run: |
-          sudo apt-get update && sudo apt-get install --yes python3-setuptools
-          sudo pip3 install -r requirements.txt
-
-      - name: Install dependencies
-        run: sudo pip3 install coverage
+      - name: Install dotrun
+        uses: canonical/install-dotrun@main
 
       - name: Install node dependencies
-        run: yarn install --immutable
+        run: |
+          sudo chmod -R 777 .
+          dotrun install
+
+      - name: Install dependencies
+        run: dotrun exec pip3 install coverage
 
       - name: Build resources
-        run: yarn build
+        run: dotrun build
 
       - name: Run tests with coverage
         run: |
-          coverage run  --source=. -m unittest discover tests
+          dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. --module unittest discover tests
           bash <(curl -s https://codecov.io/bash) -cF python
 
   test-js:


### PR DESCRIPTION
## Done

- Switched to dotrun for tests

## QA

- Check that the CI job `test-python` completes successfully

## Issue / Card

Fixes [Failing CI action](https://github.com/canonical/microstack.run/actions/runs/8925291718/job/24513634166?pr=255)
