### PR TITLE
Fix sunbeam launch typo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -215,7 +215,7 @@ MicroStack delivers distilled OpenStack excellence with native K8s experience. O
           <h3 class="p-stepped-list__title u-sv2">Launch a cloud instance</h3>
           <div class="p-stepped-list__content">
             <div class="p-code-snippet">
-              <pre class="p-code-snippet__block--icon"><code>sunbeam launch ubuntu -nanem test</code></pre>
+              <pre class="p-code-snippet__block--icon"><code>sunbeam launch ubuntu --name test</code></pre>
             </div>
           </div>
         </li>


### PR DESCRIPTION
## Done

Fix sunbeam launch typo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes LP #2066257
