### PR TITLE
WD-11587 Copyupdate: Added a flag to "install openstack instruction"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -183,7 +183,7 @@ MicroStack delivers distilled OpenStack excellence with native K8s experience. O
           <h3 class="p-stepped-list__title u-sv2">Install the snap</h3>
           <div class="p-stepped-list__content">
             <div class="p-code-snippet">
-              <pre class="p-code-snippet__block--icon"><code>sudo snap install openstack</code></pre>
+              <pre class="p-code-snippet__block--icon"><code>sudo snap install openstack --channel 2024.1/edge</code></pre>
             </div>
           </div>
         </li>


### PR DESCRIPTION
## Done
Copyupdate: Added a flag to "install openstack instruction"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8039/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [Copydoc](https://docs.google.com/document/d/1-QO5zAclj469qGvFmNJBjQ_qqI_T_uliwj6mAo8ZbCs/edit)


## Issue / Card

Fixes # [WD-11587](https://warthogs.atlassian.net/browse/WD-11587)

## Screenshots



[WD-11587]: https://warthogs.atlassian.net/browse/WD-11587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ